### PR TITLE
Fix checking existing page

### DIFF
--- a/PageAutoName.module
+++ b/PageAutoName.module
@@ -141,7 +141,7 @@ class PageAutoName extends WireData implements Module, ConfigurableModule {
             // Check if other page exists with this name
             $existingPage = $page->siblings("name=$newName")->first();
 
-            if ($existingPage->id > 0) {
+            if ($existingPage && $existingPage->id > 0) {
                 $suffix++;
             }
             else {

--- a/PageAutoName.module
+++ b/PageAutoName.module
@@ -85,7 +85,7 @@ class PageAutoName extends WireData implements Module, ConfigurableModule {
             'title' => __('Auto Name'),
             'summary' => __("Changes a page's name field after the page has been edited"),
             'author' => 'Conclurer GbR',
-            'version' => '110',
+            'version' => '111',
             'autoload' => true
         );
     }


### PR DESCRIPTION
There is a problem when checking existing page, because `first()` method called on `$page->siblings()` returns FALSE when no page is found.
